### PR TITLE
Normalize version on `get` function call, fixing capitalization bug.

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,10 +26,16 @@ module.exports = (function () {
    * @return {Promise} returns String passage
    */
   bible.get = function (psg, ver) {
-    if (typeof psg !== 'string') { throw new TypeError('Expected a string'); }
+    if (typeof psg !== 'string') {
+      throw new TypeError('Passage should be a string');
+    }
+    if (typeof ver !== 'undefined' && typeof ver !== 'string') {
+      throw new TypeError('Version should be a string');
+    }
 
     var self = this;
     var v = ver || 'asv';
+    v = v.toLowerCase();
     // clean/normalize psg to bcv object
     var psgBCV = bcv.parse(psg).parsed_entities()[0].entities[0];
 


### PR DESCRIPTION
When I tried to use the example on the README it kept throwing errors.

After a quick minute of debugging I realized it was because of the `BIBLES` object inside of `index.js`. The only two properties on the object were the lowercase 'asv' and 'kjv'. The example shown called the function using a capitalized 'ASV' and therefore didn't work as expected.

This little fix resolves the issue and any other possible mixed lower and uppercase permutations of the versions.